### PR TITLE
Fix httptrace import error

### DIFF
--- a/Dockerfile.benchmark_client
+++ b/Dockerfile.benchmark_client
@@ -1,4 +1,4 @@
-FROM golang:1.6
+FROM golang:1.7
 
 MAINTAINER Felix Abecassis "fabecassis@nvidia.com"
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Execute the following command and wait a few seconds for the initialization of t
 ```
 $ nvidia-docker run --name=server --net=host --rm inference_server
 ```
-You can use the environment variable [`NV_GPU`](https://github.com/NVIDIA/nvidia-docker/wiki/Using-nvidia-docker#gpu-isolation) to isolate GPUs for this container.
+You can use the environment variable [`NV_GPU`](https://github.com/NVIDIA/nvidia-docker/wiki/GPU-isolation) to isolate GPUs for this container.
 
 ## Single image
 Since we used [`--net=host`](https://docs.docker.com/engine/userguide/networking/), we can access our inference server from a terminal on the host using `curl`:


### PR DESCRIPTION
- Fix this error on docker build of benchmark_client:

```
package net/http/httptrace: unrecognized import path "net/http/httptrace" (import path does not begin with hostname)
The command '/bin/sh -c go get github.com/rakyll/hey' returned a non-zero code: 1
```

- Fix NV_GPU link